### PR TITLE
Fix --github arg in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ R is an experimental Ruby gem which brings Rust's [`Result`](https://doc.rust-la
 
 Install the gem and add to the application's Gemfile by executing:
 
-    $ bundle add r --github=https://github.com/olivierbellone/r
+    $ bundle add r --github=olivierbellone/r
 
 If bundler is not being used to manage dependencies, install the gem by executing:
 


### PR DESCRIPTION
It's possible a different version of Bundler expects a full URL, but I'm using Bundler 2.4 and got the error `fatal: repository 'https://github.com/https://github.com/olivierbellone/r.git/' not found`, so this removes the prefix.